### PR TITLE
Update sec8_security.md

### DIFF
--- a/sp800-63c/sec8_security.md
+++ b/sp800-63c/sec8_security.md
@@ -11,7 +11,7 @@ Since the federated authentication process involves coordination between multipl
 
 As in non-federated authentication, the motivation of attackers is typically to gain access (or a greater level of access) to a resource or service provided by an RP. Attackers may also attempt to impersonate a subscriber. Rogue or compromised IdPs, RPs, user agents (e.g., browsers), and parties outside of a typical federation transaction are potential attackers. To accomplish their attack, they might intercept or modify assertions and assertion references. Furthermore, two or more entities may attempt to subvert federation protocols by directly compromising the integrity or confidentiality of the assertion data. For the purpose of these types of threats, any authorized parties who attempt to exceed their privileges are considered attackers.
 
-In some cases, the subscriber is issued some secret information so that they can be recognized by the RP. The knowledge of this information distinguishes the subscriber from attackers who wish to impersonate them. In the case of holder-of-key assertions, this secret could already have been established with the IdP prior to the initiation of the federation protocol. In other cases, the IdP will generate a temporary secret and transmit it to the authenticated subscriber for this purpose. When this secret is used to authenticate to the RP, this temporary secret is referred to as a *secondary authenticator*. Examples of secondary authenticators include assertions in the front-channel model, session keys in Kerberos, assertion references in the back-channel model, and cookies used for session management.
+In some cases, the subscriber is issued some secret information so that they can be recognized by the RP. The knowledge of this information distinguishes the subscriber from attackers who wish to impersonate them. In the case of holder-of-key assertions, this secret could already have been established with the IdP prior to the initiation of the federation protocol.
 
 <div class="text-center" markdown="1">
 
@@ -28,8 +28,6 @@ In some cases, the subscriber is issued some secret information so that they can
 | Assertion repudiation by the subscriber | Subscriber claims not to have performed transaction | User agreement (e.g., contract) cannot be enforced |
 | Assertion redirect | Assertion can be used in unintended context | Compromised user agent passes assertion to attacker who uses it elsewhere |
 | Assertion reuse | Assertion can be used more than once with same RP | Intercepted assertion used by attacker to authenticate their own session |
-| Secondary authenticator manufacture | Attacker generates a secondary authenticator to impersonate a subscriber | Attacker exploits a cryptographic weakness in generation of secondary authenticators |
-| Secondary authenticator capture | Attacker intercepts the secondary authenticator | Attacker uses a session-hijacking attack to capture the secondary authenticator |
 | Assertion substitution | Attacker uses an assertion intended for a different subscriber | Session hijacking attack between IdP and RP |
 
 ### 8.2. Federation Threat Mitigation Strategies
@@ -48,17 +46,12 @@ Mechanisms that assist in mitigating the threats identified above are identified
 | | Send assertion over an authenticated protected channel authenticating the IdP | [7.1](#back-channel), [7.2](#front-channel) |
 | | Include a non-guessable random identifier in the assertion | [6.2.1](#assertion-id) |
 | Assertion disclosure | Send assertion over an authenticated protected channel authenticating the RP | [7.1](#back-channel), [7.2](#front-channel) |
-| | Encrypt assertion for a specific RP (may be accomplished by use of a mutually authenticated protected channel) | [6.2.3](#encrypted-assertion) |
-| Assertion repudiation by the IdP | Cryptographically sign the assertion at the IdP with a key that supports non-repudiation; verify signature at RP |
+| | Encrypt assertion for a specific RP (may be accomplished by use of a mutually authenticated protected channel) | [6.2.3](#encrypted-assertion) | [6.2.3] |
+| Assertion repudiation by the IdP | Cryptographically sign the assertion at the IdP with a key that supports non-repudiation; verify signature at RP | [6.2.2] |
 | Assertion repudiation by the subscriber | Issue holder-of-key assertions; proof of possession of presented key verifies subscriber's participation | [6.1.2](#holderofkey) |
 | Assertion redirect | Include identity of the RP ("audience") for which the assertion is issued in its signed content; RP verifies that they are intended recipient | [6](#assertions), [7.1](#back-channel), [7.2](#front-channel) |
 | Assertion reuse | Include an issuance timestamp with short validity period in the signed content of the assertion; RP verifies validity | [6](#assertions), [7.1](#back-channel), [7.2](#front-channel) |
-| | RP keeps track of assertions consumed within a configurable time window to ensure that a given assertion is not used more than once. |
-| Secondary authenticator manufacture | Ensure that secondary authenticator has sufficient entropy to resist manufacture |
-| | Include timely assertion data signed by the IdP |
-| Secondary authenticator capture | Send secondary authenticator using an authenticated protected channel established between the IdP and subscriber at primary authentication time |
-| | Use the secondary authenticator in an authentication protocol that protects against eavesdropping and MitM attacks |
-| | Never send a secondary authenticator over an unprotected channel or to an unauthenticated party while still valid |
+| | RP keeps track of assertions consumed within a configurable time window to ensure that a given assertion is not used more than once. | [6.2.1] |
 | Assertion substitution | Ensure that assertions contain a reference to the assertion request or some other nonce that was cryptographically bound to the request by the RP | [6](#assertions) |
-| | Send assertions in the same authenticated protected channel as the request, such as in the back-channel model |
+| | Send assertions in the same authenticated protected channel as the request, such as in the back-channel model |[7.1](#back-channel)|
 


### PR DESCRIPTION
added section number references to table (some need link targets in the accompanying documents still)

removed secondary authenticator references